### PR TITLE
Allow egress via IPv6

### DIFF
--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -94,6 +94,14 @@ resource "aws_security_group" "runner_sg" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
+    ipv6_cidr_blocks = [
+      "::/0",
+    ]
+  }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
   tags = merge(


### PR DESCRIPTION
The current runner security group allows outbound access to all IPv4 addresses, but not IPv6 addresses.